### PR TITLE
Minor typo correction in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ vlm.to(device, dtype=torch.bfloat16)
 # Download an image and specify a prompt
 image_url = "https://huggingface.co/adept/fuyu-8b/resolve/main/bus.png"
 image = [vlm.vision_backbone.image_transform(Image.open(requests.get(image_url, stream=True).raw).convert("RGB")).unsqueeze(0)]
-user_prompt = '<image>\nDescribe the image."
+user_prompt = "<image>\nDescribe the image."
 
 # Generate!
 generated_text = vlm.generate_batch(


### PR DESCRIPTION
A small typo update to the main python block beneath the line

```
Directly use or trial
```

The line defining the user prompt has a single quote (') on one end and a double (") on the other, causing the remainder of the code block to be wrongfully interpreted as a string.

 The original line that needs correcting:

```python
user_prompt = '<image>\nDescribe the image."
```

Updated with this PR to use double quotes at start and finish - like so

```python
user_prompt = "<image>\nDescribe the image."
```

This fixes the wrongful interpretation of the remaining code as a string in the block.